### PR TITLE
Drop taint-related code

### DIFF
--- a/lib/path/implementation.rb
+++ b/lib/path/implementation.rb
@@ -133,7 +133,6 @@ class Path
   def init
     @path = validate(@path)
 
-    taint if @path.tainted?
     @path.freeze
     freeze
   end

--- a/spec/path/identity_spec.rb
+++ b/spec/path/identity_spec.rb
@@ -146,19 +146,6 @@ describe 'Path : identity' do
     path.should == Path('a')
   end
 
-  it 'taint' do
-    Path('a'      )           .should_not be_tainted
-    Path('a'      )      .to_s.should_not be_tainted
-    Path('a'.taint)           .should be_tainted
-    Path('a'.taint)      .to_s.should be_tainted
-
-    str = 'a'
-    path = Path(str)
-    str.taint
-    path.should_not be_tainted
-    path.to_s.should_not be_tainted
-  end
-
   it 'freeze' do
     path = Path('a')
     path.freeze.should be path
@@ -171,23 +158,6 @@ describe 'Path : identity' do
     Path('a'.freeze)       .to_s.should be_frozen
     Path('a'       ).freeze.to_s.should be_frozen
     Path('a'.freeze).freeze.to_s.should be_frozen
-  end
-
-  it 'freeze, taint and untaint' do
-    path = Path('a')
-    path.should_not be_tainted
-    expect {
-      path.taint
-    }.to raise_error(*frozen_error)
-    path.     should_not be_tainted
-    path.to_s.should_not be_tainted
-
-    path = Path('a'.taint)
-    expect {
-      path.untaint
-    }.to raise_error(*frozen_error)
-    path     .should be_tainted
-    path.to_s.should be_tainted
   end
 
   it 'inspect' do

--- a/spec/path/implementation_spec.rb
+++ b/spec/path/implementation_spec.rb
@@ -378,12 +378,5 @@ describe 'Path implementation' do
 
     File.fnmatch('*.*', Path.new('bar.baz')).should be true
     File.join(Path.new('foo'), Path.new('bar')).should == 'foo/bar'
-
-    if mri?
-      lambda {
-        $SAFE = 1
-        File.join(Path.new('foo'), Path.new('bar'.taint)).should == 'foo/bar'
-      }.call
-    end
   end
 end


### PR DESCRIPTION
I read that there is a removal plan, and Ruby seems to follow it.
https://blog.saeloun.com/2020/02/18/ruby-2-7-access-and-setting-of-safe-warned-will-become-global-variable.html

This PR removes taint-handling.